### PR TITLE
Fix bug in checking existence of graphviz

### DIFF
--- a/keras/utils/visualize_util.py
+++ b/keras/utils/visualize_util.py
@@ -1,18 +1,16 @@
 """Utilities related to model visualization."""
 import os
+import pydot
+import imp
 
 from ..layers.wrappers import Wrapper
 from ..models import Sequential
 
 try:
-    # pydot-ng is a fork of pydot that is better maintained.
-    import pydot_ng as pydot
-except ImportError:
-    # Fall back on pydot if necessary.
-    import pydot
-if not pydot.find_graphviz():
-    raise ImportError('Failed to import pydot. You must install pydot'
-                      ' and graphviz for `pydotprint` to work.')
+    # check if pydot and graphviz exist in $PATH
+    imp.find_module('graphviz')
+except:
+    raise ImportError('You must install pydot and graphviz for `pydotprint` to work.')
 
 
 def model_to_dot(model, show_shapes=False, show_layer_names=True):


### PR DESCRIPTION
pydot_ng is no longer maintained so removed lines that import pydot_ng
pydot.find_graphviz() is deprecated in pydot so error is reported while using 
it to check the existence of graphviz